### PR TITLE
Option: matchAnyQueryToken (default false)

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -169,6 +169,10 @@ options you can configure.
 * `queryTokenizer` – A function with the signature `(query)` that transforms a
   query into an array of string tokens. **Required**.
 
+* `matchAnyQueryToken` - By default a search result must match ALL query-tokens.
+  Instead, this option returns results that match ANY query-tokens. Defaults to
+  `false`.
+
 * `initialize` – If set to `false`, the Bloodhound instance will not be 
   implicitly initialized by the constructor function. Defaults to `true`.
 

--- a/src/bloodhound/options_parser.js
+++ b/src/bloodhound/options_parser.js
@@ -15,6 +15,7 @@ var oParser = (function() {
       identify: _.stringify,
       datumTokenizer: null,
       queryTokenizer: null,
+      matchAnyQueryToken: false,
       sufficient: 5,
       indexRemote: false,
       sorter: null,

--- a/src/bloodhound/search_index.js
+++ b/src/bloodhound/search_index.js
@@ -22,6 +22,7 @@ var SearchIndex = window.SearchIndex = (function() {
     this.identify = o.identify || _.stringify;
     this.datumTokenizer = o.datumTokenizer;
     this.queryTokenizer = o.queryTokenizer;
+    this.matchAnyQueryToken = o.matchAnyQueryToken;
 
     this.reset();
   }
@@ -78,7 +79,7 @@ var SearchIndex = window.SearchIndex = (function() {
         var node, chars, ch, ids;
 
         // previous tokens didn't share any matches
-        if (matches && matches.length === 0) {
+        if (matches && matches.length === 0 && !that.matchAnyQueryToken) {
           return false;
         }
 
@@ -96,8 +97,10 @@ var SearchIndex = window.SearchIndex = (function() {
 
         // break early if we find out there are no possible matches
         else {
-          matches = [];
-          return false;
+          if (!that.matchAnyQueryToken) {
+            matches = [];
+            return false;
+          }
         }
       });
 

--- a/test/bloodhound/search_index_spec.js
+++ b/test/bloodhound/search_index_spec.js
@@ -54,9 +54,16 @@ describe('SearchIndex', function() {
     expect(this.index.search('wtf')).toEqual([]);
   });
 
-  it('#serach should handle multi-token queries', function() {
+  it('#search should handle multi-token queries', function() {
     this.index.add({ value: 'foo bar' });
     expect(this.index.search('foo b')).toEqual([{ value: 'foo bar' }]);
+  });
+
+  it('#search should return results that match ANY query-token when options.matchAnyQueryToken', function() {
+    this.index = build({matchAnyQueryToken:true});
+    this.index.add({ value: 'foo bar' });
+    expect(this.index.search('blah bar')).toEqual([{ value: 'foo bar' }]);
+    expect(this.index.search('food bark')).toEqual([]);
   });
 
   it('#all should return all datums', function() {


### PR DESCRIPTION
Bloodhound's tokenizer functions are a really powerful way to tune the search.  Unfortunately this flexibility ends at `SearchIndex.prototype.search`.  Currently datums must match ALL query-tokens (with no option to match ANY query-token).  This pull request adds the option: 

> `matchAnyQueryToken` - By default a search result must match ALL query-tokens.
> Instead, this option returns results that match ANY query-tokens. 
> Defaults to `false`

Inspired by [Elasticsearch's ``MUST`` and ``SHOULD``](http://stackoverflow.com/a/28768600/1636878), matching ANY query-token opens up the possibility for more fuzzy search strategies.  For more details see the [tests](https://github.com/chip-miller/typeahead.js/blob/4b7482c5bd666e255910791bb3248056112df67a/test/bloodhound/search_index_spec.js#L62-L67) and the following example:

```javascript
var index = new SearchIndex({
  datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
  queryTokenizer: Bloodhound.tokenizers.whitespace,
  matchAnyQueryToken: true,
});

index.add({ value: 'food bar' });
index.search('fod bar'); // return { value: 'food bar' }
```

**Note:** Ideally this option could change from search-to-search.  But I didn't want to clutter the `Bloodhound#search` api.