### PR TITLE
Fix old amd module loading issues

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,7 +145,7 @@ module.exports = function(grunt) {
       },
       typeahead: {
         src: '<%= tempDir %>/typeahead.jquery.js',
-        amdModuleId: 'typeahead.js',
+        amdModuleId: 'typeahead-js',
         deps: {
           default: ['$'],
           amd: ['jquery'],


### PR DESCRIPTION
RequireJS/AMD module names may not end with dotjs...

See https://github.com/twitter/typeahead.js/issues/1211