### PR TITLE
Stop propagation when selecting an entry

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -162,7 +162,10 @@ var Typeahead = (function() {
       var $selectable;
 
       if ($selectable = this.menu.getActiveSelectable()) {
-        this.select($selectable) && $e.preventDefault();
+        if (this.select($selectable)) {
+          $e.preventDefault();
+          $e.stopPropagation();
+        }
       }
     },
 

--- a/test/typeahead/typeahead_spec.js
+++ b/test/typeahead/typeahead_spec.js
@@ -284,7 +284,7 @@ describe('Typeahead', function() {
 
     beforeEach(function() {
       eventName = 'enterKeyed';
-      payload = jasmine.createSpyObj('event', ['preventDefault']);
+      payload = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
     });
 
     describe('when idle', function() {
@@ -330,7 +330,7 @@ describe('Typeahead', function() {
         expect(this.view.select).toHaveBeenCalledWith($el);
       });
 
-      it('should prevent default if active selectale ', function() {
+      it('should prevent default and stop propagation if active selectable ', function() {
         var $el;
 
         $el = $('<bah>');
@@ -340,6 +340,7 @@ describe('Typeahead', function() {
         this.input.trigger(eventName, payload);
 
         expect(payload.preventDefault).toHaveBeenCalled();
+        expect(payload.stopPropagation).toHaveBeenCalled();
       });
 
       it('should not select selectable if there is no active one', function() {


### PR DESCRIPTION
See twitter/typeahead.js#1095

Selecting an entry doesn't stop the propagation, and causes a nasty effect when there are handlers on the keypress on a textarea, such as submitting the form.

This PR stops the propagation when pressing enter, as a default.

If you're not happy with it being a default, do you consider making it an option?

Thanks
