### PR TITLE
Npm postinstall step to npm to cater for easy setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,13 @@ env:
   - secure: kehbNCoYUG2gLnhmCH/oKhlJG6LoxgcOPMCtY7KOI4ropG8qlypb+O2b/19+BWeO3aIuMB0JajNh3p2NL0UKgLmUK7EYBA9fQz+vesFReRk0V/KqMTSxHJuseM4aLOWA2Wr9US843VGltfODVvDN5sNrfY7RcoRx2cTK/k1CXa8=
 node_js: 
 - 0.11.13
-before_script: 
+before_install:
 - npm install -g grunt-cli@0.1.13
 - npm install -g node-static@0.7.3
 - npm install -g bower@1.3.8
-- bower install
+install:
+- npm install
+before_script:
 - grunt build
 script: test/ci
 addons:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "yiewd": "^0.5.0"
   },
   "scripts": {
+   "postinstall": "bower install",
     "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },
   "version": "0.11.1",


### PR DESCRIPTION
(copied over from https://github.com/twitter/typeahead.js/pull/1406, since that project has comments about being abandoned)


With this change, `npm install` ends by running `bower install`

This means that we can cut down the steps for getting started and running tests. 

Now we are down to:

1. `npm install`
2. `npm test`

(npm postinstall step runs automatically). Read more about npm's hooks here: https://docs.npmjs.com/misc/scripts


This also has changes in `.travis.yml` since installation of bower need to run before `npm install` task