### PR TITLE
Fixed npm error: adding License link

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       "url": "https://twitter.com/vskarich"
     }
   ],
+  "license" : "See license in LICENSE",
   "dependencies": {
     "jquery": ">=1.7"
   },


### PR DESCRIPTION
this fixes the error 'npm WARN EPACKAGEJSON typeahead.js@0.11.1 No license field.'