### PR TITLE
Speed up Travis: Cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
-env: 
-  matrix: 
+env:
+  matrix:
   - TEST_SUITE=unit
   - TEST_SUITE=integration BROWSER='firefox'
   - TEST_SUITE=integration BROWSER='firefox:3.5'
@@ -13,11 +13,15 @@ env:
   - TEST_SUITE=integration BROWSER='internet explorer:10'
   - TEST_SUITE=integration BROWSER='internet explorer:11'
   - TEST_SUITE=integration BROWSER='chrome'
-  global: 
+  global:
   - secure: VY4J2ERfrMEin++f4+UDDtTMWLuE3jaYAVchRxfO2c6PQUYgR+SW4SMekz855U/BuptMtiVMR2UUoNGMgOSKIFkIXpPfHhx47G5a541v0WNjXfQ2qzivXAWaXNK3l3C58z4dKxgPWsFY9JtMVCddJd2vQieAILto8D8G09p7bpo=
   - secure: kehbNCoYUG2gLnhmCH/oKhlJG6LoxgcOPMCtY7KOI4ropG8qlypb+O2b/19+BWeO3aIuMB0JajNh3p2NL0UKgLmUK7EYBA9fQz+vesFReRk0V/KqMTSxHJuseM4aLOWA2Wr9US843VGltfODVvDN5sNrfY7RcoRx2cTK/k1CXa8=
-node_js: 
+node_js:
 - 0.11.13
+cache:
+  directories:
+    - node_modules
+    - bower_components
 before_install:
 - npm install -g grunt-cli@0.1.13
 - npm install -g bower@1.3.8


### PR DESCRIPTION
Attempt to speed up Travis builds with Travis cache directive.

This should hopefully give a lot of speed improvements, since most time building
is spent by downloading dependencies.

NOTE that there is a tradeoff in stability (going both ways, actually).

If caching, we can occasionally risk strange errors for `node_modules` folder not being up-to-date. This also will happen when npm changes from version 2 to 3 (3 has flat structure in node_modules). 

Not caching will eliminate that risk. But on the other hand, there is a risk that retrieval of npm deps will face rare timeouts. The more downloads, the more frequent this will happen. So, not caching will not necessarily always increase stability.

Thoughts on this, @corejavascript/collaborators