### PR TITLE
update travis to run latest supported node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - secure: VY4J2ERfrMEin++f4+UDDtTMWLuE3jaYAVchRxfO2c6PQUYgR+SW4SMekz855U/BuptMtiVMR2UUoNGMgOSKIFkIXpPfHhx47G5a541v0WNjXfQ2qzivXAWaXNK3l3C58z4dKxgPWsFY9JtMVCddJd2vQieAILto8D8G09p7bpo=
   - secure: kehbNCoYUG2gLnhmCH/oKhlJG6LoxgcOPMCtY7KOI4ropG8qlypb+O2b/19+BWeO3aIuMB0JajNh3p2NL0UKgLmUK7EYBA9fQz+vesFReRk0V/KqMTSxHJuseM4aLOWA2Wr9US843VGltfODVvDN5sNrfY7RcoRx2cTK/k1CXa8=
 node_js:
-- 0.11.13
+- "4.1"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
node 0.11 was actually unsupported by some of the packages (some required 0.10 or 0.12)

Reason for updating to 4.1:
* latest that is installed in Travis (although 4.2 is released)
* will work even though that we will get warnings from a few dependencies that wants 0.10 or 0.12

the warning

```
npm WARN engine karma@0.12.37: wanted: {"node":">=0.8 <=0.12 || >=1 <=2"} (current: {"node":"4.1.2","npm":"2.14.7"})
```