### PR TITLE
https://github.com/corejavascript/typeahead.js/issues/33

### DIFF
--- a/dist/typeahead.bundle.js
+++ b/dist/typeahead.bundle.js
@@ -2182,14 +2182,10 @@
                 return false;
             },
             autocomplete: function autocomplete($selectable) {
-                var query, data, isValid;
-                query = this.input.getQuery();
-                data = this.menu.getSelectableData($selectable);
-                isValid = data && query !== data.val;
-                if (isValid && !this.eventBus.before("autocomplete", data.obj)) {
+                var data = this.menu.getSelectableData($selectable);
+                if (!this.eventBus.before("autocomplete", data.obj)) {
                     this.input.setQuery(data.val);
                     this.eventBus.trigger("autocomplete", data.obj);
-                    return true;
                 }
                 return false;
             },

--- a/dist/typeahead.jquery.js
+++ b/dist/typeahead.jquery.js
@@ -1259,14 +1259,10 @@
                 return false;
             },
             autocomplete: function autocomplete($selectable) {
-                var query, data, isValid;
-                query = this.input.getQuery();
-                data = this.menu.getSelectableData($selectable);
-                isValid = data && query !== data.val;
-                if (isValid && !this.eventBus.before("autocomplete", data.obj)) {
+                var data = this.menu.getSelectableData($selectable);
+                if (!this.eventBus.before("autocomplete", data.obj)) {
                     this.input.setQuery(data.val);
                     this.eventBus.trigger("autocomplete", data.obj);
-                    return true;
                 }
                 return false;
             },

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -361,20 +361,12 @@ var Typeahead = (function() {
     },
 
     autocomplete: function autocomplete($selectable) {
-      var query, data, isValid;
+      var data = this.menu.getSelectableData($selectable);
 
-      query = this.input.getQuery();
-      data = this.menu.getSelectableData($selectable);
-      isValid = data && query !== data.val;
-
-      if (isValid && !this.eventBus.before('autocomplete', data.obj)) {
+      if (!this.eventBus.before('autocomplete', data.obj)) {
         this.input.setQuery(data.val);
         this.eventBus.trigger('autocomplete', data.obj);
-
-        // return true if autocompletion succeeded
-        return true;
       }
-
       return false;
     },
 


### PR DESCRIPTION
For my purposes this change fixes the issue. Although I have changed 3 files, it is the same change in all three places.

I honestly do *not* have a full understanding of the surrounding code, so this is very much a change that should be reviewed. But for my project, this works much better. The undesired behaviour is described in the bug description ( https://github.com/corejavascript/typeahead.js/issues/33 ) and the new behaviour is that 
(a) when the whole exact string is typed in (e.g. a 4 digit invoice number in the case of my application) and then tab is pressed, the autocomplete event will still be fired and hence the bound function will be called with the correct, associated data from bloodhound.
(b) when less than the whole string is typed in (e.g. 3 digits of an invoice number) and then tab is pressed, the autocomplete event will complete the selection as before, but will also move focus out of the component and close the menu. This is as I want it.