### PR TITLE
Removed requirement to have bower when installing with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "yiewd": "^0.6.0"
   },
   "scripts": {
-    "postinstall": "bower install",
     "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },
   "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "yiewd": "^0.6.0"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
+    "test": "bower install && ./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },
   "version": "0.11.1",
   "main": "dist/typeahead.bundle.js"

--- a/test/ci
+++ b/test/ci
@@ -1,8 +1,10 @@
 #!/bin/bash -x
 
 if [ "$TEST_SUITE" == "unit" ]; then
+  bower install
   ./node_modules/karma/bin/karma start --single-run --browsers PhantomJS
 elif [ "$TRAVIS_SECURE_ENV_VARS" == "true" -a "$TEST_SUITE" == "integration" ]; then
+  bower install
   ./node_modules/.bin/static -p 8888 &
   sleep 3
   # integration tests are flaky, don't let them fail the build


### PR DESCRIPTION
When installing with NPM it tries to run "bower install" but if bower does not exist NPM will fail. I don't see why this is needed when installing via NPM.