### PR TITLE
Add option to update dropdown menu only after async callback is done

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -55,6 +55,8 @@ var Dataset = (function() {
     // a hint to figuring out of the source will return async suggestions
     this.async = _.isUndefined(o.async) ? this.source.length > 2 : !!o.async;
 
+    this.updateOnAsync = _.isUndefined(o.updateOnAsync) || !this.async ? false : o.updateOnAsync;
+
     this._resetLastSuggestion();
 
     this.$el = $(o.node)
@@ -234,7 +236,7 @@ var Dataset = (function() {
     // ### public
 
     update: function update(query) {
-      var that = this, canceled = false, syncCalled = false, rendered = 0;
+      var that = this, canceled = false, syncCalled = false, rendered = 0, unrenderedSuggestions = [];
 
       // cancel possible pending update
       this.cancel();
@@ -253,9 +255,12 @@ var Dataset = (function() {
 
         syncCalled = true;
         suggestions = (suggestions || []).slice(0, that.limit);
-        rendered = suggestions.length;
 
-        that._overwrite(query, suggestions);
+        if (!that.updateOnAsync) {
+          rendered = suggestions.length;
+          that._overwrite(query, suggestions);
+        } else
+          unrenderedSuggestions = suggestions;
 
         if (rendered < that.limit && that.async) {
           that.trigger('asyncRequested', query);
@@ -263,15 +268,19 @@ var Dataset = (function() {
       }
 
       function async(suggestions) {
-        suggestions = suggestions || [];
+        suggestions = unrenderedSuggestions.concat(suggestions).slice(0, that.limit - rendered);
 
         // if the update has been canceled or if the query has changed
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          var idx = Math.abs(rendered - that.limit);
-          rendered += idx;
-          that._append(query, suggestions.slice(0, idx));
+
+          if (!that.updateOnAsync)
+            that._append(query, suggestions);
+          else
+            that._overwrite(query, suggestions);
+		
+          rendered += suggestions.length;
           that.async && that.trigger("asyncReceived", query);
         }
       }


### PR DESCRIPTION
# Add option to refresh suggestion list on DOM only after async callback is done

On some use cases it can be useful to render the search suggestions after all suggestions are available from synchronous and asynchronous callback of a dataset. So, the flag "updateOnAsync" is introduced to have the possibility to activate the new mode, to render the whole result after asynchronous callback only.

If you want to display the whole result only, then this mode can be used now. Also, if you work with asynchronous data only and will not use a pending template, this mode ensures to prevent closing and reopen the dropdown menu on keypress (which can be misinterpreted as an ugly flickering, while the user types something) provokes by the empty or unused synchronous callback.