### PR TITLE
Remove cursor on mouseleave

### DIFF
--- a/src/typeahead/menu.js
+++ b/src/typeahead/menu.js
@@ -104,6 +104,7 @@ var Menu = (function() {
       onSelectableClick = _.bind(this._onSelectableClick, this);
       this.$node.on('click.tt', this.selectors.selectable, onSelectableClick);
       this.$node.on('mouseover', this.selectors.selectable, function(){ that.setCursor($(this)) });
+      this.$node.on('mouseleave', function(){ that._removeCursor(); });
 
       _.each(this.datasets, function(dataset) {
         dataset

--- a/test/typeahead/menu_spec.js
+++ b/test/typeahead/menu_spec.js
@@ -33,6 +33,30 @@ describe('Menu', function() {
     });
   });
 
+  describe('when mouseover event is triggered on a selectable', function() {
+    it('should call setCursor', function() {
+      var $selectable;
+      spyOn(this.view, 'setCursor');
+
+      this.view.bind();
+      $selectable = this.$node.find(www.selectors.selectable).first();
+      $selectable.trigger('mouseover');
+
+      expect(this.view.setCursor).toHaveBeenCalledWith($selectable);
+    });
+  });
+
+  describe('when mouseleave event is triggered on the menu', function() {
+    it('should call _removeCursor', function() {
+      spyOn(this.view, '_removeCursor');
+
+      this.view.bind();
+      this.$node.trigger('mouseleave');
+
+      expect(this.view._removeCursor).toHaveBeenCalled();
+    });
+  });
+
   describe('when rendered is triggered on a dataset', function() {
     it('should add empty class to node if empty', function() {
       this.dataset.isEmpty.andReturn(true);


### PR DESCRIPTION
Related to #28.

When using the mouse to select suggestions the selected suggestion is set on hover. When leaving the suggestions menu with the mouse the last selection is kept.

With this PR the selection is removed when leaving the suggestions menu with the mouse.