### PR TITLE
(Second try to merge it) fingerprint crashes when o.data is a string

### DIFF
--- a/src/bloodhound/transport.js
+++ b/src/bloodhound/transport.js
@@ -47,7 +47,10 @@ var Transport = (function() {
 
     _fingerprint: function fingerprint(o) {
       o = o || {};
-      return o.url + o.type + $.param(o.data || {});
+      //$.param(o.data || {}) crashes because it does not expect a single string value.
+      //if o.data is string no need to call param
+
+	  return o.url + o.type + (o.data &&_.isString(o.data) ? o.data : $.param(o.data || {}));
     },
 
     _get: function(o, cb) {


### PR DESCRIPTION
new Bloodhound({
    datumTokenizer: Bloodhound.tokenizers.whitespace,
    queryTokenizer: Bloodhound.tokenizers.whitespace,
    aprefetch: '',
    remote: {
        url: .....',
        prepare: function(query, settings) {
            settings.type = 'POST';
            settings.contentType = 'application/json; charset=UTF-8';
            // Data will go into POST request body, not querystring
            settings.data = JSON.stringify({ q: query });
            return settings;
        }
    }
});
In the above scenario, settings.data should go into the request body, not into querystring. The argument name-value pairs should be in JSON format (eg {"objName":"Value"}), not in querystring format (eg objName=Value).
Therefore, we set settings.data = JSON.stringify({ q: query }); - a string value.
However, this doesn't bode well for function fingerprint(o):

$.param(o.data || {}) crashes because it does not expect a single string value.