### PR TITLE
Add jQuery 3 compatibility

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -223,8 +223,8 @@
     .removeData()
     .css(www.css.hint)
     .css(getBackgroundStyles($input))
-    .prop('readonly', true)
-    .removeAttr('id name placeholder required')
+    .prop({ readonly: true, required: false })
+    .removeAttr('id name placeholder')
     .attr({ spellcheck: 'false', tabindex: -1 });
   }
 


### PR DESCRIPTION
`removeAttr` cannot be used with boolean attributes (`required`).
Instead, use `prop('required', false)`.