### PR TITLE
Add documentation for the transport option

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -272,6 +272,17 @@ When configuring `remote`, the following options are available.
   you to transform the remote response before the Bloodhound instance operates 
   on it. Defaults to the [identity function].
 
+* `transport` – A function with the signature `transport(options, onSuccess, onError)`
+  that allows you to specify a custom transport:
+  ```javascript
+  transport: function (options, onSuccess, onError) {
+    // Modify the options or replace the next line
+    $.ajax(options)
+      .done(function(data, textStatus, request) { onSuccess(data); })
+      .fail(function(request, textStatus, errorThrown) { onError(errorThrown); });
+  }
+  ```
+
 <!-- section links -->
 
 [identity function]: http://en.wikipedia.org/wiki/Identity_function


### PR DESCRIPTION
This was inspired by:

http://stackoverflow.com/questions/33156774/using-http-post-with-typeahead-js-and-bloodhound-js

and 

https://github.com/twitter/typeahead.js/issues/907