### PR TITLE
compare same as sorting

### DIFF
--- a/src/bloodhound/search_index.js
+++ b/src/bloodhound/search_index.js
@@ -174,11 +174,11 @@ var SearchIndex = window.SearchIndex = (function() {
     var lenArrayA = arrayA.length, lenArrayB = arrayB.length;
 
     while (ai < lenArrayA && bi < lenArrayB) {
-      if (arrayA[ai] < arrayB[bi]) {
+      if (arrayA[ai].toString() < arrayB[bi].toString()) {
         ai++;
       }
 
-      else if (arrayA[ai] > arrayB[bi]) {
+      else if (arrayA[ai].toString() > arrayB[bi].toString()) {
         bi++;
       }
 


### PR DESCRIPTION
There is a huge bug.
If my ids are integers, they got sorted as string ( from js definition of sort - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort ), but compared as integers.
It is not really working for me!!