### PR TITLE
Selection via enter keypress doesn't stop the keypress immediate event propagation

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -172,12 +172,12 @@ var Typeahead = (function() {
       if ($selectable = this.menu.getActiveSelectable()) {
         if (this.select($selectable)){
             $e.preventDefault();
-            $e.stopPropagation();
+            $e.stopImmediatePropagation();
         }
       } else if(this.autoselect) {
         if (this.select(this.menu.getTopSelectable())) {
             $e.preventDefault();
-            $e.stopPropagation();
+            $e.stopImmediatePropagation();
         }
       }
     },


### PR DESCRIPTION
Selection via enter keypress doesn't stop the keypress immediate event propagation. This means that when selecting an item the enter keydown event will be received by other handlers on the same element.