### PR TITLE
Fix selectors from css classes

### DIFF
--- a/src/typeahead/www.js
+++ b/src/typeahead/www.js
@@ -53,7 +53,9 @@ var WWW = (function() {
 
   function buildSelectors(classes) {
     var selectors = {};
-    _.each(classes, function(v, k) { selectors[k] = '.' + v; });
+    _.each(classes, function(v, k) {
+      selectors[k] = v.split(' ').map(function(className) { return '.' + className; }).join();
+    });
 
     return selectors;
   }


### PR DESCRIPTION
Cursor (and perhaps other features) breaks if multiple `className`s are provided for styling.
- Convert `className` to selector properly