### PR TITLE
fix unsupported sort

### DIFF
--- a/src/bloodhound/search_index.js
+++ b/src/bloodhound/search_index.js
@@ -168,8 +168,12 @@ var SearchIndex = window.SearchIndex = (function() {
   function getIntersection(arrayA, arrayB) {
     var ai = 0, bi = 0, intersection = [];
 
-    arrayA = arrayA.sort();
-    arrayB = arrayB.sort();
+    arrayA = arrayA.sort(function(a, b) {
+        return a - b;
+    });
+    arrayB = arrayB.sort(function(a, b) {
+        return a - b;
+    });
 
     var lenArrayA = arrayA.length, lenArrayB = arrayB.length;
 


### PR DESCRIPTION
since the logic within `getIntersection` depends on the values being sorted correctly (`arrayA[ai] < arrayB[bi]`) and .sort is not stable and even gives a wrong result according to decimal computation( [14,2].sort() = [14,2], so we must at least give the `compareFunction` for simple cases (which fits to our needs, as we compare Ids).