### PR TITLE
on up/down arrow, set the input only if data.val is a string

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -415,7 +415,11 @@ var Typeahead = (function() {
 
         // cursor moved to different selectable
         if (data) {
-          this.input.setInputValue(data.val);
+          // set the input only if data.val is a string
+          // don't want to set it to [Object object]
+          if (typeof data.val === 'string') {
+            this.input.setInputValue(data.val);
+          }
         }
 
         // cursor moved off of selectables, back to input

--- a/test/typeahead/typeahead_spec.js
+++ b/test/typeahead/typeahead_spec.js
@@ -16,6 +16,7 @@ describe('Typeahead', function() {
     this.$input = $fixture.find('input');
 
     testData = { dataset: 'bar', val: 'foo bar', obj: 'fiz' };
+    testObjectData = { dataset: 'bar', val: { id: 1, name: 'foo bar' }, obj: { id: 1, name: 'foo bar' } };
 
     this.view = new Typeahead({
       input: new Input(),
@@ -1381,6 +1382,14 @@ describe('Typeahead', function() {
 
       this.view.moveCursor(1);
       expect(this.input.setInputValue).toHaveBeenCalledWith(testData.val);
+    });
+
+    it('should not update the input value if moved to object selectable', function() {
+      this.menu.getSelectableData.andReturn(testObjectData);
+      this.menu.selectableRelativeToCursor.andReturn($());
+
+      this.view.moveCursor(1);
+      expect(this.input.setInputValue).not.toHaveBeenCalled();
     });
 
     it('should reset the input value if moved to input', function() {


### PR DESCRIPTION
Enter search text, then click a down arrow; it sets the value of the input:

https://github.com/corejavascript/typeahead.js/blob/master/src/typeahead/typeahead.js#L416

        // cursor moved to different selectable
        if (data) {
          this.input.setInputValue(data.val);
        }

but if the dataset contains objects, this will set the input to `[object Object]`:

<img width="333" alt="screen shot 2018-05-07 at 6 40 14 am" src="https://user-images.githubusercontent.com/1649528/39708826-0908469a-51cd-11e8-9045-faa3927f4015.png">

Arrows should only navigate through suggestions; clicking an arrow should not redo the search for just the highlighted suggestion. This change skips setting the input value if data is not a string.

<img width="335" alt="screen shot 2018-05-07 at 6 37 48 am" src="https://user-images.githubusercontent.com/1649528/39709091-cb546314-51cd-11e8-865c-c15ffc3c3127.png">
