### PR TITLE
Apply accessibility attributes to suggestion template

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -319,8 +319,13 @@ var Dataset = (function() {
       pending: templates.pending && _.templatify(templates.pending),
       header: templates.header && _.templatify(templates.header),
       footer: templates.footer && _.templatify(templates.footer),
-      suggestion: templates.suggestion || suggestionTemplate
+      suggestion: templates.suggestion ? userSuggestionTemplate : suggestionTemplate
     };
+
+    function userSuggestionTemplate(context) {
+      var template = templates.suggestion;
+      return $(template(context)).attr("id", _.guid());
+    }
 
     function suggestionTemplate(context) {
       return $('<div role="option">').attr('id', _.guid()).text(displayFn(context));

--- a/test/typeahead/dataset_spec.js
+++ b/test/typeahead/dataset_spec.js
@@ -421,6 +421,33 @@ describe('Dataset', function() {
     });
   });
 
+  it('should apply id attribute when using default suggestion template', function() {
+    this.dataset = new Dataset({
+      source: this.source,
+      node: $('<div>'),
+    }, www);
+
+    this.source.andCallFake(syncMockSuggestions);
+    this.dataset.update('woah');
+
+    expect(this.dataset.$el.find('div[role="option"]')).toHaveAttr('id');
+  });
+
+  it('should apply id attribute when using custom suggestion template', function() {
+    this.dataset = new Dataset({
+      source: this.source,
+      node: $('<div>'),
+      templates: {
+        suggestion: function(c) { return '<p class="search-result"> result' + c.query + '</p>'; }
+      }
+    }, www);
+
+    this.source.andCallFake(syncMockSuggestions);
+    this.dataset.update('woah');
+
+    expect(this.dataset.$el.find('p.search-result')).toHaveAttr('id');
+  });
+
   describe('#clear', function() {
     it('should clear suggestions', function() {
       this.source.andCallFake(syncMockSuggestions);


### PR DESCRIPTION
When the suggestion template is customised, the accessibility related attributes are no longer applied.

This results in screen readers not reading the selected element. This behaviour has been observed in JAWS 18 running under Internet Explorer 11.

The Aria-activedescendant attribute is used to link the input text field to the current selection. I have updated dataset.js to apply the id (generated by guid()) in the event a user customises the template.

Example of user generated template:

````
templates: {
    suggestion: function (data) {
        if (data.isUserEntered) {
            return '<div style="font-weight:bold">Use entered address:<br/>' + data.searchPickListDescription + '</div>';
        }
        else {
            return '<div class="matching-address">' + data.searchPickListDescription + '</div>';
        }
    }
}
````

