### PR TITLE
Makes the 'val' method set the query silently.

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -176,6 +176,24 @@
       }
 
       else {
+        // Sets the query in 'silent' mode so that it doesn't fire
+        // an autocomplete request.
+        ttEach(this, function(t) { t.setVal(_.toStr(newVal), true); });
+        return this;
+      }
+    },
+
+    // Same thing as the 'val' method, except it allows events to
+    // be triggered that execute autocomplete requests (namely, queryChanged).
+    query: function query(newVal) {
+      var query;
+
+      if (!arguments.length) {
+        ttEach(this.first(), function(t) { query = t.getVal(); });
+        return query;
+      }
+
+      else {
         ttEach(this, function(t) { t.setVal(_.toStr(newVal)); });
         return this;
       }

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -351,9 +351,12 @@ var Typeahead = (function() {
       return !this.isOpen();
     },
 
-    setVal: function setVal(val) {
+    setVal: function setVal(val, silent) {
+      if(silent){
+        this.menu.empty();
+      }
       // expect val to be a string, so be safe, and coerce
-      this.input.setQuery(_.toStr(val));
+      this.input.setQuery(_.toStr(val), silent);
     },
 
     getVal: function getVal() {

--- a/test/typeahead/plugin_spec.js
+++ b/test/typeahead/plugin_spec.js
@@ -78,7 +78,7 @@ describe('$plugin', function() {
 
     // activate and set val to render some selectables
     this.$input.typeahead('activate');
-    this.$input.typeahead('val', 'o');
+    this.$input.typeahead('query', 'o');
     $el = $('.tt-selectable').first();
 
     expect(this.$input.typeahead('select', $el)).toBe(true);
@@ -90,7 +90,7 @@ describe('$plugin', function() {
 
     // activate and set val to render some selectables
     this.$input.typeahead('activate');
-    this.$input.typeahead('val', 'o');
+    this.$input.typeahead('query', 'o');
     body = document.body;
 
     expect(this.$input.typeahead('select', body)).toBe(false);
@@ -101,7 +101,7 @@ describe('$plugin', function() {
 
     // activate and set val to render some selectables
     this.$input.typeahead('activate');
-    this.$input.typeahead('val', 'o');
+    this.$input.typeahead('query', 'o');
     $el = $('.tt-selectable').first();
 
     expect(this.$input.typeahead('autocomplete', $el)).toBe(true);
@@ -113,7 +113,7 @@ describe('$plugin', function() {
 
     // activate and set val to render some selectables
     this.$input.typeahead('activate');
-    this.$input.typeahead('val', 'o');
+    this.$input.typeahead('query', 'o');
     body = document.body;
 
     expect(this.$input.typeahead('autocomplete', body)).toBe(false);
@@ -124,7 +124,7 @@ describe('$plugin', function() {
 
     // activate and set val to render some selectables
     this.$input.typeahead('activate');
-    this.$input.typeahead('val', 'o');
+    this.$input.typeahead('query', 'o');
     $el = $('.tt-selectable').first();
 
     expect($el).not.toHaveClass('tt-cursor');
@@ -137,7 +137,7 @@ describe('$plugin', function() {
 
     // activate and set val to render some selectables
     this.$input.typeahead('activate');
-    this.$input.typeahead('val', 'o');
+    this.$input.typeahead('query', 'o');
     body = document.body;
 
     expect(this.$input.typeahead('select', body)).toBe(false);
@@ -150,11 +150,13 @@ describe('$plugin', function() {
     $els = this.$input.add('<div>');
 
     expect($els.typeahead('val')).toBe('foo');
+    expect($els.typeahead('query')).toBe('foo');
   });
 
   it('#val(q) should set query', function() {
     this.$input.typeahead('val', 'foo');
     expect(this.$input.typeahead('val')).toBe('foo');
+    expect(this.$input.typeahead('query')).toBe('foo');
   });
 
   it('#val(q) should coerce null and undefined to empty string', function() {
@@ -163,6 +165,48 @@ describe('$plugin', function() {
 
     this.$input.typeahead('val', undefined);
     expect(this.$input.typeahead('val')).toBe('');
+  });
+
+  it('#val(q) should set query silently', function() {
+    var $el;
+
+    // activate and set val to render some selectables
+    this.$input.typeahead('activate');
+    this.$input.typeahead('val', 'o');
+    expect($('.tt-selectable').length).toBe(0)
+  });
+
+  it('#query() should typeahead value of element', function() {
+    var $els;
+
+    this.$input.typeahead('query', 'foo');
+    $els = this.$input.add('<div>');
+
+    expect($els.typeahead('val')).toBe('foo');
+    expect($els.typeahead('query')).toBe('foo');
+  });
+
+  it('#query(q) should set query', function() {
+    this.$input.typeahead('query', 'foo');
+    expect(this.$input.typeahead('val')).toBe('foo');
+    expect(this.$input.typeahead('query')).toBe('foo');
+  });
+
+  it('#query(q) should coerce null and undefined to empty string', function() {
+    this.$input.typeahead('query', null);
+    expect(this.$input.typeahead('query')).toBe('');
+
+    this.$input.typeahead('query', undefined);
+    expect(this.$input.typeahead('query')).toBe('');
+  });
+
+  it('#query(q) should set query noisily', function() {
+    var $el;
+
+    // activate and set query to render some selectables
+    this.$input.typeahead('activate');
+    this.$input.typeahead('query', 'o');
+    expect($('.tt-selectable').length).toBe(3)
   });
 
   it('#destroy should revert modified attributes', function() {

--- a/test/typeahead/typeahead_spec.js
+++ b/test/typeahead/typeahead_spec.js
@@ -1173,8 +1173,8 @@ describe('Typeahead', function() {
   describe('#setVal', function() {
     it('should update query', function() {
       this.input.hasFocus.andReturn(true);
-      this.view.setVal('woah');
-      expect(this.input.setQuery).toHaveBeenCalledWith('woah');
+      this.view.setVal('woah', true);
+      expect(this.input.setQuery).toHaveBeenCalledWith('woah', true);
     });
   });
 


### PR DESCRIPTION
Currently, the only time 'silent' is used when setting the query is in
the default 'select' method (here: https://github.com/corejavascript/typeahead.js/blob/master/src/typeahead/typeahead.js#L367); an item is selected, and the value is set
silently such that another query to the autocompleter won't be made. I
believe this should always happen when triggering $element.typeahead('val',
aValue);

When I manually call 'val' on a typeahead object, it is never because I
want to autocomplete a result. It is because I am populating that value
either from a selected dataset (custom render/select method) or from
another source. This redundant querying can cause problems when the
source is a remote that charges per request, for example (mapquest
autocomplete addresses, in my case).

If you *truly* want to fill in an input value and trigger an
autocomplete request, use the new 'query' method instead.

