### PR TITLE
Return all results when no query is present.

### DIFF
--- a/src/bloodhound/search_index.js
+++ b/src/bloodhound/search_index.js
@@ -103,6 +103,13 @@ var SearchIndex = window.SearchIndex = (function() {
           }
         }
       });
+      
+      if (!query) {
+        matches = [];
+        for (var obj in that.datums) {
+          matches.push(obj);
+        }
+      }
 
       return matches ?
         _.map(unique(matches), function(id) { return that.datums[id]; }) : [];


### PR DESCRIPTION
This allows you to set `minLength: 0` and get default values back when a query is run.

This is a PR of @NipunaMarcus's work in this Issue: https://github.com/corejavascript/typeahead.js/issues/44

Will likely need to update the dist version as well. But hoping to get some 👀 on this and get it merged in so we can use the main branch in our app.