### PR TITLE
Fix bug in limiting rendered suggestions (#189)

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -273,9 +273,9 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          var idx = Math.abs(rendered - that.limit);
-          rendered += idx;
-          that._append(query, suggestions.slice(0, idx));
+          var suggestionsToAdd = suggestions.slice(0, that.limit - rendered);
+          that._append(query, suggestionsToAdd);
+          rendered += suggestionsToAdd.length;
           that.async && that.trigger('asyncReceived', query, that.name);
         }
       }


### PR DESCRIPTION
As the title says: fixes the bug reported in #189 where the more suggestions there are to render, the less will be rendered, due to faulty render limit logic 