### PR TITLE
improvement - allow partial head and footer for suggestions

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -141,9 +141,9 @@ var Dataset = (function() {
       $fragment = this._getSuggestionsFragment(query, suggestions);
       this.$lastSuggestion = $fragment.children().last();
 
-      this.$el.html($fragment)
-      .prepend(this._getHeader(query, suggestions))
-      .append(this._getFooter(query, suggestions));
+      let newHtml = $([this._getHeader(query, suggestions),'<div id="__corejs-typeahead-suggestions-placeholder__"></div>',this._getFooter(query, suggestions)].join(''));
+				newHtml.find('#__corejs-typeahead-suggestions-placeholder__').replaceWith($fragment);
+				this.$el.html(newHtml);
     },
 
     _appendSuggestions: function appendSuggestions(query, suggestions) {


### PR DESCRIPTION
Previously the header and footer for suggestions had to be full html elements. 
Example:
head=`<div>The Head</div>` and footer=`<div>The footer</div>`. 

If we wanted to have:
header=`<ul>`
footer=`</ul>`
and have the suggestions to be `<li>`'s, the typeahead would generate wrong html.

This change makes it so that it works in both scenarios.